### PR TITLE
fix return value bug causing crash with blocks in retainBlock

### DIFF
--- a/HeapInspector/NSObject+HeapInspector.m
+++ b/HeapInspector/NSObject+HeapInspector.m
@@ -181,9 +181,7 @@ id objc_retainBlock(id value)
     if (value) {
         recordAndRegisterIfPossible(value,"retainBlock");
     }
-    [value copy];
-    
-    return value;
+    return [value copy];
 }
 
 id objc_release(id value)


### PR DESCRIPTION
I found the crash I mentioned in https://github.com/tapwork/HeapInspector-for-iOS/issues/2 is related to this bug.

It should return the address of copied object, via: http://clang.llvm.org/docs/AutomaticReferenceCounting.html

And according to the doc, if the object is no longer on stack (actually I didn't quite understand the meaning of on stack, retainCount > 0?), it should be retained instead of copied.

But with this fix, at least blocks won't crash with HeapInspector enabled.
