### PR TITLE
bugfix/canRecordObject fix

### DIFF
--- a/HeapInspector/NSObject+HeapInspector.m
+++ b/HeapInspector/NSObject+HeapInspector.m
@@ -217,7 +217,7 @@ static inline bool canRecordObject(id obj)
         // NSProxy sub classes will cause crash when calling class_getName on its class
         return false;
     }
-    Class cls = [obj class];
+    Class cls = object_getClass(obj);
     bool canRecord = true;
     const char *name = class_getName(cls);
     if (recordClassPrefix && name) {


### PR DESCRIPTION
HeapInspector-for-iOS is not compatible with ReactiveCocoa , because [obj class] in canRecordObject method will cause stack overflow when rac_signalForSelector is called in ReactiveCocoa.
